### PR TITLE
Handle invalid conversion time values

### DIFF
--- a/data-processor.js
+++ b/data-processor.js
@@ -251,7 +251,7 @@ class DataProcessor {
     
     this.rawData.forEach(row => {
       const convDate = row['Conversion Time'] ? new Date(row['Conversion Time']) : null;
-      if (convDate) {
+      if (convDate && !isNaN(convDate.getTime())) {
         if (!minDate || convDate < minDate) minDate = convDate;
         if (!maxDate || convDate > maxDate) maxDate = convDate;
       }
@@ -297,8 +297,11 @@ class DataProcessor {
     const conversionTimeline = {};
     this.rawData.forEach(row => {
       if (row['Conversion Time']) {
-        const date = new Date(row['Conversion Time']).toISOString().split('T')[0];
-        conversionTimeline[date] = (conversionTimeline[date] || 0) + 1;
+        const convDate = new Date(row['Conversion Time']);
+        if (!isNaN(convDate.getTime())) {
+          const date = convDate.toISOString().split('T')[0];
+          conversionTimeline[date] = (conversionTimeline[date] || 0) + 1;
+        }
       }
     });
     


### PR DESCRIPTION
## Summary
- Avoid RangeError by skipping invalid "Conversion Time" values when building summary and timeline data

## Testing
- `node --check data-processor.js`


------
https://chatgpt.com/codex/tasks/task_e_68a726bf7fbc832295066a2bf3dbfc92