### PR TITLE
Show x-axis labels for bar charts

### DIFF
--- a/chart-visualizer.js
+++ b/chart-visualizer.js
@@ -29,7 +29,13 @@ class ChartVisualizer {
       };
       Chart.defaults.scales.category = {
         grid: { display: false, drawBorder: false },
-        ticks: { color: '#6b7280', font: { size: 12 } }
+        ticks: {
+          color: '#6b7280',
+          font: { size: 12 },
+          callback: function(value) {
+            return this.getLabelForValue(value);
+          }
+        }
       };
       Chart.defaults.scales.time = {
         grid: { color: 'rgba(0,0,0,0.05)', drawBorder: false },


### PR DESCRIPTION
## Summary
- ensure category scales display their associated labels instead of numeric indices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae095db58883229ab723047d08638c